### PR TITLE
Enhance navigation and add additional developer tools

### DIFF
--- a/DevTools/Pages/Index.razor
+++ b/DevTools/Pages/Index.razor
@@ -1,94 +1,165 @@
-﻿@page "/"
+@page "/"
 
-<div class="max-w-screen-xl mx-auto">
-    <div class="text-center mb-12">
-        <h1 class="text-4xl font-bold text-gray-800 mb-4">Developer Tools</h1>
-        <p class="text-xl text-gray-600">A collection of helpful tools for developers</p>
+<div class="max-w-screen-xl mx-auto space-y-8">
+    <div class="text-center space-y-3">
+        <h1 class="text-4xl font-bold text-gray-800">Developer Tools</h1>
+        <p class="text-lg md:text-xl text-gray-600">
+            A growing collection of everyday helpers for busy developers.
+        </p>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <!-- Replace Line Breaks Tool -->
-
-        <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
-            href="replacelinebreaks">
-            <div class="p-6">
-                <div class="w-12 h-12 bg-blue-100 text-blue-600 rounded-lg flex items-center justify-center mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                        stroke="currentColor" class="w-6 h-6">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-                    </svg>
-                </div>
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Replace Line Breaks</h2>
-                <p class="text-gray-600">Convert between line breaks and other formats like SQL queries, comma-separated
-                    lists, and more.</p>
-            </div>
-        </NavLink>
-
-        <!-- GUID Helpers Tool -->
-        <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
-            href="guidhelpers">
-            <div class="p-6">
-                <div class="w-12 h-12 bg-green-100 text-green-600 rounded-lg flex items-center justify-center mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                        stroke="currentColor" class="w-6 h-6">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
-                    </svg>
-                </div>
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">GUID Helpers</h2>
-                <p class="text-gray-600">Generate GUIDs, convert between GUID and long/int values, and split GUIDs into
-                    components.</p>
-            </div>
-        </NavLink>
-
-        <!-- String Formatter Tool -->
-        <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
-            href="stringformatter">
-            <div class="p-6">
-                <div class="w-12 h-12 bg-purple-100 text-purple-600 rounded-lg flex items-center justify-center mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                        stroke="currentColor" class="w-6 h-6">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-                    </svg>
-                </div>
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">String Formatter</h2>
-                <p class="text-gray-600">Format JSON and SQL, change case, and perform Base64/URL encoding and decoding.
-                </p>
-            </div>
-        </NavLink>
-
-        <!-- JSON Edit/Sort Tool -->
-        <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
-            href="jsoneditsort">
-            <div class="p-6">
-                <div class="w-12 h-12 bg-yellow-100 text-yellow-600 rounded-lg flex items-center justify-center mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                        stroke="currentColor" class="w-6 h-6">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" />
-                    </svg>
-                </div>
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">JSON Edit/Sort</h2>
-                <p class="text-gray-600">Sort JSON data by property and exclude specific fields from the output.</p>
-            </div>
-        </NavLink>
-
-        <!-- Compare Tool -->
-        <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
-            href="compare">
-            <div class="p-6">
-                <div class="w-12 h-12 bg-red-100 text-red-600 rounded-lg flex items-center justify-center mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                        stroke="currentColor" class="w-6 h-6">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 00-3.7-3.7 48.678 48.678 0 00-7.324 0 4.006 4.006 0 00-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3l-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 003.7 3.7 48.656 48.656 0 007.324 0 4.006 4.006 0 003.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3l-3 3" />
-                    </svg>
-                </div>
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Compare Tool</h2>
-                <p class="text-gray-600">Compare text or code side by side with an interactive diff editor.</p>
-            </div>
-        </NavLink>
+    <div class="bg-white rounded-lg shadow-md p-6">
+        <label for="tool-search" class="block text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+            Find a tool
+        </label>
+        <div class="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 focus-within:border-blue-400">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd"
+                      d="M12.9 14.32a8 8 0 111.414-1.414l4.387 4.387a1 1 0 01-1.414 1.414l-4.387-4.387zM14 8a6 6 0 11-12 0 6 6 0 0112 0z"
+                      clip-rule="evenodd" />
+            </svg>
+            <input id="tool-search"
+                   @bind="searchTerm"
+                   @bind:event="oninput"
+                   type="search"
+                   placeholder="Search by name or description..."
+                   class="w-full bg-transparent focus:outline-none text-gray-700" />
+        </div>
+        <p class="text-xs text-gray-500 mt-2">
+            Type to quickly filter the tools below. New additions are highlighted for easy discovery.
+        </p>
     </div>
+
+    <section class="space-y-6">
+        <h2 class="text-2xl font-semibold text-gray-800">All tools</h2>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            @if (!FilteredTools.Any())
+            {
+                <div class="col-span-full">
+                    <div class="bg-white border border-dashed border-gray-300 rounded-lg p-8 text-center text-gray-500">
+                        No tools matched your search. Try a different keyword or clear the search box.
+                    </div>
+                </div>
+            }
+            else
+            {
+                foreach (var tool in FilteredTools)
+                {
+                    <NavLink class="tool-card bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow"
+                             href="@tool.Route">
+                        <div class="p-6 flex flex-col h-full">
+                            <div class="flex items-start gap-4 mb-4">
+                                <div class=@$"w-12 h-12 {tool.IconClasses} rounded-lg flex items-center justify-center">
+                                    @((MarkupString)tool.IconSvg)
+                                </div>
+                                <div class="flex-1 space-y-1">
+                                    <div class="flex items-center gap-2">
+                                        <h3 class="text-xl font-semibold text-gray-800">@tool.Title</h3>
+                                        @if (!string.IsNullOrWhiteSpace(tool.Badge))
+                                        {
+                                            <span class=@$"text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full {tool.BadgeClasses}">
+                                                @tool.Badge
+                                            </span>
+                                        }
+                                    </div>
+                                    <p class="text-sm text-gray-600 leading-relaxed">@tool.Description</p>
+                                </div>
+                            </div>
+                            <div class="mt-auto text-sm text-blue-600 font-medium flex items-center gap-1">
+                                <span>Open tool</span>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5H5.25A2.25 2.25 0 003 6.75v11a2.25 2.25 0 002.25 2.25h11a2.25 2.25 0 002.25-2.25V10.5m-6-6h6m0 0v6m0-6L10.5 15" />
+                                </svg>
+                            </div>
+                        </div>
+                    </NavLink>
+                }
+            }
+        </div>
+    </section>
 </div>
+
+@code {
+    private string? searchTerm;
+
+    private IEnumerable<ToolCard> FilteredTools => string.IsNullOrWhiteSpace(searchTerm)
+        ? toolCards
+        : toolCards.Where(tool =>
+            tool.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+            tool.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+
+    private readonly List<ToolCard> toolCards = new()
+    {
+        new(
+            "Replace Line Breaks",
+            "Convert line separated content into SQL statements, comma separated lists, and more.",
+            "replacelinebreaks",
+            "bg-blue-100 text-blue-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z\" /></svg>")
+        ,
+        new(
+            "GUID Helpers",
+            "Generate GUIDs and convert between GUID values and long/int representations.",
+            "guidhelpers",
+            "bg-green-100 text-green-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23-.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5\" /></svg>")
+        ,
+        new(
+            "String Formatter",
+            "Format JSON, SQL and text, switch casing, and encode or decode Base64/URLs.",
+            "stringformatter",
+            "bg-purple-100 text-purple-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 4.5h18M3 9h18M9 13.5h6M4.5 18h15\" /></svg>")
+        ,
+        new(
+            "JSON Edit/Sort",
+            "Sort JSON objects by property, remove fields, and tidy payloads for sharing.",
+            "jsoneditsort",
+            "bg-yellow-100 text-yellow-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z\" /></svg>")
+        ,
+        new(
+            "Compare Tool",
+            "Review differences between two snippets with an interactive diff editor.",
+            "compare",
+            "bg-red-100 text-red-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 00-3.7-3.7 48.678 48.678 0 00-7.324 0 4.006 4.006 0 00-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3l-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 003.7 3.7 48.656 48.656 0 007.324 0 4.006 4.006 0 003.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3l-3 3\" /></svg>")
+        ,
+        new(
+            "Unix Timestamp Converter",
+            "Quickly convert between Unix timestamps and human-readable dates in UTC or local time.",
+            "unixtimestamp",
+            "bg-indigo-100 text-indigo-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z\" /></svg>",
+            "New",
+            "bg-indigo-100 text-indigo-700")
+        ,
+        new(
+            "JWT Decoder",
+            "Decode and pretty-print JSON Web Tokens without sending data to a server.",
+            "jwtdecoder",
+            "bg-emerald-100 text-emerald-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M16.5 10.5V6.75A2.25 2.25 0 0014.25 4.5h-9A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h9a2.25 2.25 0 002.25-2.25V13.5m0-3l3 3m-3-3l-3 3\" /></svg>",
+            "New",
+            "bg-emerald-100 text-emerald-700")
+        ,
+        new(
+            "Regex Tester",
+            "Experiment with .NET regular expressions, view captured groups, and test replacements.",
+            "regextester",
+            "bg-orange-100 text-orange-600",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M8.25 6.75h9m-9 3H12m-5.25 3h9m-9 3H12m7.5-9L21 9.75m-1.5 3L21 15.75m-1.5 3L21 21\" /></svg>",
+            "New",
+            "bg-orange-100 text-orange-700")
+    };
+
+    private record ToolCard(
+        string Title,
+        string Description,
+        string Route,
+        string IconClasses,
+        string IconSvg,
+        string? Badge = null,
+        string? BadgeClasses = null);
+}

--- a/DevTools/Pages/JwtDecoder.razor
+++ b/DevTools/Pages/JwtDecoder.razor
@@ -1,0 +1,392 @@
+@page "/jwtdecoder"
+@inject IJSRuntime JSRuntime
+@using System.Text
+@using System.Text.Json
+@using System.Globalization
+@using System.Linq
+
+<div class="max-w-screen-xl mx-auto space-y-8">
+    <div>
+        <h1 class="text-3xl font-bold text-gray-800">JWT Decoder</h1>
+        <p class="text-gray-600 mt-2">
+            Inspect JSON Web Tokens safely in your browser. Decode the header and payload, review key claims, and copy
+            formatted JSON without sending your token across the network.
+        </p>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-md p-6 space-y-4">
+        <label class="block text-sm font-medium text-gray-700" for="jwt-input">Paste a JWT</label>
+        <textarea id="jwt-input" @bind="jwtInput" class="w-full h-40 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"
+                  placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."></textarea>
+        <div class="flex flex-wrap gap-3">
+            <button class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors" @onclick="DecodeJwt">
+                Decode token
+            </button>
+            <button class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors" @onclick="ClearAll">
+                Clear
+            </button>
+        </div>
+        <p class="text-xs text-gray-500">
+            Tokens are decoded entirely in your browser. Secrets never leave this page.
+        </p>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(decodeError))
+    {
+        <div class="rounded-md bg-red-50 border border-red-200 text-red-700 text-sm px-4 py-3">
+            @decodeError
+        </div>
+    }
+    else if (headerClaims is not null && payloadClaims is not null)
+    {
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div class="bg-white rounded-lg shadow-md p-6 space-y-4">
+                <div class="flex items-center justify-between">
+                    <h2 class="text-xl font-semibold text-gray-800">Header</h2>
+                    <button id="copy-header" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(headerJson, "copy-header")" title="Copy header JSON">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="bg-gray-50 border border-gray-200 rounded-md p-3 text-sm">
+                    <pre class="whitespace-pre-wrap break-all font-mono text-xs">@headerJson</pre>
+                </div>
+                <table class="w-full text-sm text-left">
+                    <tbody>
+                        @foreach (var claim in headerClaims)
+                        {
+                            <tr class="border-b border-gray-100 last:border-none">
+                                <td class="py-1 pr-3 font-semibold text-gray-700">@claim.Key</td>
+                                <td class="py-1 text-gray-600">@claim.Value</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="bg-white rounded-lg shadow-md p-6 space-y-4">
+                <div class="flex items-center justify-between">
+                    <h2 class="text-xl font-semibold text-gray-800">Payload</h2>
+                    <button id="copy-payload" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(payloadJson, "copy-payload")" title="Copy payload JSON">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="bg-gray-50 border border-gray-200 rounded-md p-3 text-sm">
+                    <pre class="whitespace-pre-wrap break-all font-mono text-xs">@payloadJson</pre>
+                </div>
+                <div class="space-y-2 text-sm">
+                    @if (!string.IsNullOrWhiteSpace(subjectClaim))
+                    {
+                        <p><span class="font-semibold text-gray-700">Subject:</span> <span class="text-gray-600">@subjectClaim</span></p>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(audienceClaim))
+                    {
+                        <p><span class="font-semibold text-gray-700">Audience:</span> <span class="text-gray-600">@audienceClaim</span></p>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(issuerClaim))
+                    {
+                        <p><span class="font-semibold text-gray-700">Issuer:</span> <span class="text-gray-600">@issuerClaim</span></p>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(issuedAtSummary) || !string.IsNullOrWhiteSpace(expiresAtSummary) || !string.IsNullOrWhiteSpace(notBeforeSummary))
+                    {
+                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs text-gray-500">
+                            @if (!string.IsNullOrWhiteSpace(issuedAtSummary))
+                            {
+                                <div class="bg-gray-50 border border-gray-200 rounded-md p-3">
+                                    <span class="block font-semibold uppercase text-gray-500">Issued</span>
+                                    <span class="block">@issuedAtSummary</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(notBeforeSummary))
+                            {
+                                <div class="bg-gray-50 border border-gray-200 rounded-md p-3">
+                                    <span class="block font-semibold uppercase text-gray-500">Valid from</span>
+                                    <span class="block">@notBeforeSummary</span>
+                                </div>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(expiresAtSummary))
+                            {
+                                <div class="bg-gray-50 border border-gray-200 rounded-md p-3">
+                                    <span class="block font-semibold uppercase text-gray-500">Expires</span>
+                                    <span class="block">@expiresAtSummary</span>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+                <table class="w-full text-sm text-left">
+                    <tbody>
+                        @foreach (var claim in payloadClaims)
+                        {
+                            <tr class="border-b border-gray-100 last:border-none">
+                                <td class="py-1 pr-3 font-semibold text-gray-700">@claim.Key</td>
+                                <td class="py-1 text-gray-600">@claim.Value</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-lg shadow-md p-6 space-y-3">
+            <h2 class="text-xl font-semibold text-gray-800">Signature</h2>
+            <p class="text-sm text-gray-600">
+                The signature verifies the token was issued by a trusted party. You can copy it for debugging or to
+                compare with another token.
+            </p>
+            <div class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-md p-3 font-mono text-xs break-all">
+                <span>@signature</span>
+                <button id="copy-signature" class="text-gray-500 hover:text-gray-700 ml-3" @onclick="() => CopyAsync(signature, "copy-signature")" title="Copy signature">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private string? jwtInput;
+    private string? headerJson;
+    private string? payloadJson;
+    private Dictionary<string, string>? headerClaims;
+    private Dictionary<string, string>? payloadClaims;
+    private string? signature;
+    private string? decodeError;
+    private string? issuedAtSummary;
+    private string? expiresAtSummary;
+    private string? notBeforeSummary;
+    private string? subjectClaim;
+    private string? audienceClaim;
+    private string? issuerClaim;
+
+    private void DecodeJwt()
+    {
+        decodeError = null;
+        headerJson = null;
+        payloadJson = null;
+        headerClaims = null;
+        payloadClaims = null;
+        signature = null;
+        issuedAtSummary = null;
+        expiresAtSummary = null;
+        notBeforeSummary = null;
+        subjectClaim = null;
+        audienceClaim = null;
+        issuerClaim = null;
+
+        if (string.IsNullOrWhiteSpace(jwtInput))
+        {
+            decodeError = "Paste a JWT to decode.";
+            return;
+        }
+
+        var parts = jwtInput.Split('.');
+        if (parts.Length < 2)
+        {
+            decodeError = "A JWT must contain at least a header and payload separated by periods.";
+            return;
+        }
+
+        try
+        {
+            headerJson = FormatJson(Base64UrlDecode(parts[0]));
+            payloadJson = FormatJson(Base64UrlDecode(parts[1]));
+            signature = parts.Length > 2 ? parts[2] : string.Empty;
+
+            headerClaims = ParseClaims(headerJson);
+            payloadClaims = ParseClaims(payloadJson);
+
+            if (payloadClaims is not null)
+            {
+                payloadClaims.Remove("exp");
+                payloadClaims.Remove("nbf");
+                payloadClaims.Remove("iat");
+            }
+
+            if (!string.IsNullOrWhiteSpace(payloadJson))
+            {
+                using var payloadDoc = JsonDocument.Parse(payloadJson);
+                var root = payloadDoc.RootElement;
+                issuedAtSummary = GetTimeClaim(root, "iat");
+                expiresAtSummary = GetTimeClaim(root, "exp");
+                notBeforeSummary = GetTimeClaim(root, "nbf");
+                subjectClaim = TryGetString(root, "sub");
+                issuerClaim = TryGetString(root, "iss");
+                audienceClaim = ExtractAudience(root);
+            }
+        }
+        catch (Exception ex)
+        {
+            decodeError = $"Unable to decode token: {ex.Message}";
+        }
+    }
+
+    private void ClearAll()
+    {
+        jwtInput = string.Empty;
+        headerJson = null;
+        payloadJson = null;
+        headerClaims = null;
+        payloadClaims = null;
+        signature = null;
+        decodeError = null;
+        issuedAtSummary = null;
+        expiresAtSummary = null;
+        notBeforeSummary = null;
+        subjectClaim = null;
+        audienceClaim = null;
+        issuerClaim = null;
+    }
+
+    private static string Base64UrlDecode(string input)
+    {
+        var sanitized = input.Replace('-', '+').Replace('_', '/');
+        switch (sanitized.Length % 4)
+        {
+            case 2:
+                sanitized += "==";
+                break;
+            case 3:
+                sanitized += "=";
+                break;
+        }
+
+        var bytes = Convert.FromBase64String(sanitized);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private static string FormatJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return string.Empty;
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+    }
+
+    private static Dictionary<string, string>? ParseClaims(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        var result = new Dictionary<string, string>();
+        foreach (var property in doc.RootElement.EnumerateObject())
+        {
+            result[property.Name] = FormatValue(property.Value);
+        }
+
+        return result;
+    }
+
+    private static string FormatValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString() ?? string.Empty,
+            JsonValueKind.Number => element.TryGetInt64(out var longValue)
+                ? longValue.ToString(CultureInfo.InvariantCulture)
+                : element.GetDouble().ToString(CultureInfo.InvariantCulture),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => "null",
+            JsonValueKind.Array => string.Join(", ", element.EnumerateArray().Select(FormatValue)),
+            JsonValueKind.Object => JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = false }),
+            _ => element.ToString()
+        };
+    }
+
+    private static string? GetTimeClaim(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var element))
+        {
+            return null;
+        }
+
+        if (!element.TryGetInt64(out var unix))
+        {
+            return null;
+        }
+
+        var dto = DateTimeOffset.FromUnixTimeSeconds(unix);
+        var relative = BuildRelative(dto);
+        return $"{dto.ToUniversalTime():yyyy-MM-dd HH:mm:ss 'UTC'} ({relative})";
+    }
+
+    private static string BuildRelative(DateTimeOffset dto)
+    {
+        var diff = DateTimeOffset.UtcNow - dto;
+        var direction = diff.TotalSeconds >= 0 ? "ago" : "from now";
+        var span = diff.Duration();
+
+        string unit;
+        double value;
+        if (span.TotalDays >= 1)
+        {
+            value = span.TotalDays;
+            unit = "day";
+        }
+        else if (span.TotalHours >= 1)
+        {
+            value = span.TotalHours;
+            unit = "hour";
+        }
+        else if (span.TotalMinutes >= 1)
+        {
+            value = span.TotalMinutes;
+            unit = "minute";
+        }
+        else
+        {
+            value = span.TotalSeconds;
+            unit = "second";
+        }
+
+        var rounded = Math.Max(1, (int)Math.Round(value));
+        return rounded == 1
+            ? $"{rounded} {unit} {direction}"
+            : $"{rounded} {unit}s {direction}";
+    }
+
+    private static string? TryGetString(JsonElement root, string propertyName)
+    {
+        return root.TryGetProperty(propertyName, out var element) && element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : null;
+    }
+
+    private static string? ExtractAudience(JsonElement root)
+    {
+        if (!root.TryGetProperty("aud", out var element))
+        {
+            return null;
+        }
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Array => string.Join(", ", element.EnumerateArray().Select(e => e.ValueKind == JsonValueKind.String ? e.GetString() : e.ToString())),
+            _ => element.ToString()
+        };
+    }
+
+    private async Task CopyAsync(string? value, string buttonId)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            await JSRuntime.InvokeVoidAsync("copyToClipboard", value, buttonId);
+        }
+    }
+}

--- a/DevTools/Pages/RegexTester.razor
+++ b/DevTools/Pages/RegexTester.razor
@@ -1,0 +1,298 @@
+@page "/regextester"
+@using System.Text
+@using System.Text.RegularExpressions
+@using System.Net
+@using System.Linq
+
+<div class="max-w-screen-xl mx-auto space-y-8">
+    <div>
+        <h1 class="text-3xl font-bold text-gray-800">Regex Tester</h1>
+        <p class="text-gray-600 mt-2">
+            Quickly experiment with .NET regular expressions. Toggle common options, highlight matches, view captured
+            groups, and test replacements without leaving your browser.
+        </p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-2 bg-white rounded-lg shadow-md p-6 space-y-5">
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1" for="pattern-input">Pattern</label>
+                <input id="pattern-input" type="text" @bind="pattern" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm" placeholder="^\\w+@\\w+\\.com$" />
+            </div>
+
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1" for="test-input">Test text</label>
+                <textarea id="test-input" @bind="testText" class="w-full h-48 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm"></textarea>
+            </div>
+
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1" for="replacement-input">Replacement (optional)</label>
+                <input id="replacement-input" type="text" @bind="replacement" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm" placeholder="$1" />
+            </div>
+
+            <div class="flex flex-wrap gap-4 text-sm text-gray-700">
+                <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" @bind="ignoreCase" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                    Ignore case
+                </label>
+                <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" @bind="multiline" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                    Multiline
+                </label>
+                <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" @bind="singleline" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                    Singleline (dotall)
+                </label>
+                <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" @bind="explicitCapture" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                    Explicit capture
+                </label>
+            </div>
+
+            <div class="flex flex-wrap gap-3">
+                <button class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors" @onclick="RunRegex">
+                    Test pattern
+                </button>
+                <button class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors" @onclick="Clear">
+                    Clear
+                </button>
+            </div>
+
+            <div class="flex flex-wrap gap-2 text-xs text-gray-500">
+                <span class="uppercase tracking-wide font-semibold">Examples:</span>
+                <button class="underline hover:text-blue-600" @onclick='() => LoadExample("Email", "^\\w+[\\w\\.-]*@\\w+[\\w\\.-]*\\.\\w+$", "john.doe@example.com\ninvalid-email")'>Email</button>
+                <button class="underline hover:text-blue-600" @onclick='() => LoadExample("GUID", "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$", "Valid: 3F2504E0-4F89-11D3-9A0C-0305E82C3301\nOops: 1234")'>GUID</button>
+                <button class="underline hover:text-blue-600" @onclick='() => LoadExample("Numbers", "-?\\d+\\.?\\d*", "42\n-5\n3.14\nnot a number")'>Numbers</button>
+            </div>
+        </div>
+
+        <div class="bg-white rounded-lg shadow-md p-6 space-y-4">
+            <h2 class="text-xl font-semibold text-gray-800">Quick tips</h2>
+            <ul class="list-disc list-inside text-sm text-gray-600 space-y-2">
+                <li>Toggle <strong>multiline</strong> to have <code>^</code>/<code>$</code> match at each line boundary.</li>
+                <li><strong>Singleline</strong> (dotall) lets <code>.</code> match newline characters.</li>
+                <li><strong>Explicit capture</strong> ignores unnamed groups unless you use <code>(?&lt;name&gt;...)</code>.</li>
+                <li>Use numbered groups (<code>$1</code>) or named groups (<code>${group}</code>) in the replacement box.</li>
+            </ul>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(regexError))
+    {
+        <div class="rounded-md bg-red-50 border border-red-200 text-red-700 text-sm px-4 py-3">
+            @regexError
+        </div>
+    }
+    else if (matches.Count > 0 || !string.IsNullOrEmpty(testText))
+    {
+        <div class="bg-white rounded-lg shadow-md p-6 space-y-5">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h2 class="text-xl font-semibold text-gray-800">Results</h2>
+                    <p class="text-sm text-gray-600">@matches.Count match@(matches.Count == 1 ? string.Empty : "es") found.</p>
+                </div>
+                <button class="px-3 py-2 text-sm bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors" @onclick="RunRegex">
+                    Re-run
+                </button>
+            </div>
+
+            <div class="bg-gray-900 rounded-md text-green-100 text-sm p-4 font-mono overflow-x-auto">
+                <div class="whitespace-pre-wrap" style="word-break: break-word;">
+                    @((MarkupString)(highlightedText ?? WebUtility.HtmlEncode(testText ?? string.Empty)))
+                </div>
+            </div>
+
+            @if (matches.Count > 0)
+            {
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-sm text-left">
+                        <thead>
+                            <tr class="text-xs uppercase tracking-wide text-gray-500">
+                                <th class="py-2 pr-4">#</th>
+                                <th class="py-2 pr-4">Index</th>
+                                <th class="py-2 pr-4">Length</th>
+                                <th class="py-2 pr-4">Match</th>
+                                <th class="py-2">Groups</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (var i = 0; i < matches.Count; i++)
+                            {
+                                var match = matches[i];
+                                <tr class="border-b border-gray-100 last:border-none align-top">
+                                    <td class="py-2 pr-4 font-semibold text-gray-700">@(i + 1)</td>
+                                    <td class="py-2 pr-4 text-gray-600">@match.Index</td>
+                                    <td class="py-2 pr-4 text-gray-600">@match.Length</td>
+                                    <td class="py-2 pr-4 text-gray-800">@match.Value</td>
+                                    <td class="py-2 text-gray-600">
+                                        @if (match.Groups.Count == 0)
+                                        {
+                                            <span class="text-xs text-gray-400">(none)</span>
+                                        }
+                                        else
+                                        {
+                                            <ul class="space-y-1">
+                                                @foreach (var group in match.Groups)
+                                                {
+                                                    <li class="text-xs">
+                                                        <span class="font-semibold text-gray-700">@group.Name</span>
+                                                        <span>→</span>
+                                                        <span class="font-mono">@group.Value</span>
+                                                        <span class="text-gray-400">(index @group.Index, length @group.Length)</span>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(replacement) && replacementResult is not null)
+            {
+                <div class="bg-blue-50 border border-blue-200 rounded-md p-4 text-sm text-blue-900">
+                    <p class="font-semibold mb-2">Replacement preview</p>
+                    <div class="whitespace-pre-wrap font-mono text-xs">@replacementResult</div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private string pattern = string.Empty;
+    private string testText = string.Empty;
+    private string? replacement;
+    private bool ignoreCase = true;
+    private bool multiline;
+    private bool singleline;
+    private bool explicitCapture;
+    private string? regexError;
+    private List<RegexMatchResult> matches = new();
+    private string? highlightedText;
+    private string? replacementResult;
+
+    private void RunRegex()
+    {
+        regexError = null;
+        highlightedText = null;
+        replacementResult = null;
+        matches = new List<RegexMatchResult>();
+
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            regexError = "Enter a pattern to start testing.";
+            return;
+        }
+
+        try
+        {
+            var options = RegexOptions.None;
+            if (ignoreCase)
+            {
+                options |= RegexOptions.IgnoreCase;
+            }
+            if (multiline)
+            {
+                options |= RegexOptions.Multiline;
+            }
+            if (singleline)
+            {
+                options |= RegexOptions.Singleline;
+            }
+            if (explicitCapture)
+            {
+                options |= RegexOptions.ExplicitCapture;
+            }
+
+            var regex = new Regex(pattern, options);
+            var input = testText ?? string.Empty;
+            var matchesCollection = regex.Matches(input);
+            var groupNames = regex.GetGroupNames().Where(name => name != "0").ToArray();
+
+            foreach (Match match in matchesCollection)
+            {
+                var groups = new List<GroupResult>();
+                foreach (var name in groupNames)
+                {
+                    var group = match.Groups[name];
+                    if (group.Success)
+                    {
+                        groups.Add(new GroupResult(name, group.Index, group.Length, group.Value));
+                    }
+                }
+
+                matches.Add(new RegexMatchResult(match.Index, match.Length, match.Value, groups));
+            }
+
+            highlightedText = BuildHighlightedText(input, matches);
+
+            if (!string.IsNullOrEmpty(replacement))
+            {
+                replacementResult = regex.Replace(input, replacement);
+            }
+        }
+        catch (Exception ex)
+        {
+            regexError = ex.Message;
+            matches.Clear();
+        }
+    }
+
+    private void Clear()
+    {
+        pattern = string.Empty;
+        testText = string.Empty;
+        replacement = string.Empty;
+        matches.Clear();
+        highlightedText = null;
+        replacementResult = null;
+        regexError = null;
+    }
+
+    private void LoadExample(string name, string examplePattern, string exampleText)
+    {
+        pattern = examplePattern;
+        testText = exampleText;
+        replacement = name == "Email" ? "$0" : string.Empty;
+        RunRegex();
+    }
+
+    private static string BuildHighlightedText(string input, IReadOnlyCollection<RegexMatchResult> results)
+    {
+        if (string.IsNullOrEmpty(input) || results.Count == 0)
+        {
+            return WebUtility.HtmlEncode(input);
+        }
+
+        var ordered = results.OrderBy(m => m.Index).ToList();
+        var builder = new StringBuilder();
+        var current = 0;
+        foreach (var match in ordered)
+        {
+            if (match.Index > current)
+            {
+                builder.Append(WebUtility.HtmlEncode(input[current..match.Index]));
+            }
+
+            builder.Append("<mark class=\"bg-yellow-200 text-gray-900 rounded px-0.5\">");
+            builder.Append(WebUtility.HtmlEncode(input.Substring(match.Index, match.Length)));
+            builder.Append("</mark>");
+            current = match.Index + match.Length;
+        }
+
+        if (current < input.Length)
+        {
+            builder.Append(WebUtility.HtmlEncode(input[current..]));
+        }
+
+        return builder.ToString();
+    }
+
+    private record RegexMatchResult(int Index, int Length, string Value, List<GroupResult> Groups);
+
+    private record GroupResult(string Name, int Index, int Length, string Value);
+}

--- a/DevTools/Pages/UnixTimestampConverter.razor
+++ b/DevTools/Pages/UnixTimestampConverter.razor
@@ -1,0 +1,376 @@
+@page "/unixtimestamp"
+@inject IJSRuntime JSRuntime
+@using System.Globalization
+
+<div class="max-w-screen-xl mx-auto space-y-8">
+    <div>
+        <h1 class="text-3xl font-bold text-gray-800">Unix Timestamp Converter</h1>
+        <p class="text-gray-600 mt-2">
+            Convert between Unix timestamps and human-readable dates while staying offline. Quickly switch between
+            seconds and milliseconds, preview UTC versus local time, and copy results with a single click.
+        </p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white rounded-lg shadow-md p-6 space-y-5">
+            <div class="flex items-center justify-between">
+                <h2 class="text-xl font-semibold text-gray-800">Timestamp to date</h2>
+                <button class="text-sm text-blue-600 hover:text-blue-700 font-medium" @onclick="UseCurrentTimestamp">
+                    Use current time
+                </button>
+            </div>
+
+            <div class="space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="timestamp-input">Timestamp</label>
+                    <input id="timestamp-input" type="text" @bind="timestampInput" @bind:event="oninput"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                           placeholder="e.g. 1717435200" />
+                </div>
+
+                <div class="flex flex-wrap gap-4 items-center">
+                    <div>
+                        <label class="block text-xs font-semibold text-gray-600 uppercase mb-1">Units</label>
+                        <select @bind="timestampUnit" class="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                            <option value="Seconds">Seconds</option>
+                            <option value="Milliseconds">Milliseconds</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-xs font-semibold text-gray-600 uppercase mb-1">Display time</label>
+                        <select @bind="timestampOutputZone" class="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                            <option value="Utc">UTC</option>
+                            <option value="Local">Local</option>
+                            <option value="Both">Show both</option>
+                        </select>
+                    </div>
+                    <button class="ml-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+                            @onclick="ConvertTimestamp">
+                        Convert
+                    </button>
+                </div>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(timestampError))
+            {
+                <div class="rounded-md bg-red-50 border border-red-200 text-red-700 text-sm px-3 py-2">
+                    @timestampError
+                </div>
+            }
+            else if (!string.IsNullOrWhiteSpace(timestampUtc) || !string.IsNullOrWhiteSpace(timestampLocal))
+            {
+                <div class="space-y-3">
+                    @if (!string.IsNullOrWhiteSpace(timestampUtc))
+                    {
+                        <div class="flex items-start justify-between bg-gray-50 border border-gray-200 rounded-md p-3">
+                            <div>
+                                <span class="block text-xs uppercase text-gray-500 font-semibold">UTC</span>
+                                <span class="block text-gray-800 font-medium">@timestampUtc</span>
+                                <span class="block text-xs text-gray-500">@timestampUtcIso</span>
+                            </div>
+                            <button id="copy-utc" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(timestampUtc, "copy-utc")" title="Copy UTC time">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                </svg>
+                            </button>
+                        </div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(timestampLocal))
+                    {
+                        <div class="flex items-start justify-between bg-gray-50 border border-gray-200 rounded-md p-3">
+                            <div>
+                                <span class="block text-xs uppercase text-gray-500 font-semibold">Local</span>
+                                <span class="block text-gray-800 font-medium">@timestampLocal</span>
+                                <span class="block text-xs text-gray-500">@timestampLocalIso</span>
+                            </div>
+                            <button id="copy-local" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(timestampLocal, "copy-local")" title="Copy local time">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                </svg>
+                            </button>
+                        </div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(timestampRelative))
+                    {
+                        <p class="text-xs text-gray-500">@timestampRelative</p>
+                    }
+                </div>
+            }
+        </div>
+
+        <div class="bg-white rounded-lg shadow-md p-6 space-y-5">
+            <div class="flex items-center justify-between">
+                <h2 class="text-xl font-semibold text-gray-800">Date to timestamp</h2>
+                <button class="text-sm text-blue-600 hover:text-blue-700 font-medium" @onclick="UseNowForDate">
+                    Use now
+                </button>
+            </div>
+
+            <div class="space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="datetime-input">Date &amp; time</label>
+                    <input id="datetime-input" type="datetime-local" @bind="dateInput" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                </div>
+                <div>
+                    <label class="block text-xs font-semibold text-gray-600 uppercase mb-1">Interpret as</label>
+                    <select @bind="dateInterpretation" class="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="Local">Local time</option>
+                        <option value="Utc">UTC</option>
+                    </select>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                    <button class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors" @onclick="ConvertDate">
+                        Convert
+                    </button>
+                    @if (!string.IsNullOrWhiteSpace(unixSeconds))
+                    {
+                        <button class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors" @onclick="FillTimestampFromDate">
+                            Copy to other panel
+                        </button>
+                    }
+                </div>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(dateError))
+            {
+                <div class="rounded-md bg-red-50 border border-red-200 text-red-700 text-sm px-3 py-2">
+                    @dateError
+                </div>
+            }
+            else if (!string.IsNullOrWhiteSpace(unixSeconds))
+            {
+                <div class="space-y-3">
+                    <div class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-md p-3">
+                        <div>
+                            <span class="block text-xs uppercase text-gray-500 font-semibold">Unix seconds</span>
+                            <span class="block text-gray-800 font-medium">@unixSeconds</span>
+                        </div>
+                        <button id="copy-seconds" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(unixSeconds, "copy-seconds")" title="Copy seconds">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-md p-3">
+                        <div>
+                            <span class="block text-xs uppercase text-gray-500 font-semibold">Unix milliseconds</span>
+                            <span class="block text-gray-800 font-medium">@unixMilliseconds</span>
+                        </div>
+                        <button id="copy-milliseconds" class="text-gray-500 hover:text-gray-700" @onclick="() => CopyAsync(unixMilliseconds, "copy-milliseconds")" title="Copy milliseconds">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs text-gray-500">
+                        <div>
+                            <span class="block font-semibold uppercase text-gray-500">UTC</span>
+                            <span class="block">@dateUtcSummary</span>
+                        </div>
+                        <div>
+                            <span class="block font-semibold uppercase text-gray-500">Local</span>
+                            <span class="block">@dateLocalSummary</span>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    private enum TimestampUnit
+    {
+        Seconds,
+        Milliseconds
+    }
+
+    private enum TimeZoneSelection
+    {
+        Utc,
+        Local,
+        Both
+    }
+
+    private string? timestampInput = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+    private TimestampUnit timestampUnit = TimestampUnit.Seconds;
+    private TimeZoneSelection timestampOutputZone = TimeZoneSelection.Both;
+    private string? timestampUtc;
+    private string? timestampUtcIso;
+    private string? timestampLocal;
+    private string? timestampLocalIso;
+    private string? timestampRelative;
+    private string? timestampError;
+
+    private DateTime dateInput = DateTime.Now;
+    private TimeZoneSelection dateInterpretation = TimeZoneSelection.Local;
+    private string? unixSeconds;
+    private string? unixMilliseconds;
+    private string? dateUtcSummary;
+    private string? dateLocalSummary;
+    private string? dateError;
+
+    protected override void OnInitialized()
+    {
+        ConvertTimestamp();
+        ConvertDate();
+    }
+
+    private void ConvertTimestamp()
+    {
+        timestampError = null;
+        timestampUtc = null;
+        timestampUtcIso = null;
+        timestampLocal = null;
+        timestampLocalIso = null;
+        timestampRelative = null;
+
+        if (!long.TryParse(timestampInput, out var value))
+        {
+            timestampError = "Enter a valid numeric timestamp.";
+            return;
+        }
+
+        try
+        {
+            var instant = timestampUnit == TimestampUnit.Seconds
+                ? DateTimeOffset.FromUnixTimeSeconds(value)
+                : DateTimeOffset.FromUnixTimeMilliseconds(value);
+
+            var utc = instant.ToUniversalTime();
+            var local = instant.ToLocalTime();
+
+            if (timestampOutputZone is TimeZoneSelection.Utc or TimeZoneSelection.Both)
+            {
+                timestampUtc = utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+                timestampUtcIso = utc.ToString("O", CultureInfo.InvariantCulture);
+            }
+
+            if (timestampOutputZone is TimeZoneSelection.Local or TimeZoneSelection.Both)
+            {
+                var localFormat = "yyyy-MM-dd HH:mm:ss 'GMT'zzz";
+                timestampLocal = local.ToString(localFormat, CultureInfo.InvariantCulture);
+                timestampLocalIso = local.ToString("O", CultureInfo.InvariantCulture);
+            }
+
+            timestampRelative = BuildRelativeDescription(utc);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            timestampError = ex.Message;
+        }
+    }
+
+    private void ConvertDate()
+    {
+        dateError = null;
+
+        try
+        {
+            var kind = dateInterpretation switch
+            {
+                TimeZoneSelection.Utc => DateTimeKind.Utc,
+                TimeZoneSelection.Local => DateTimeKind.Local,
+                _ => DateTimeKind.Local
+            };
+
+            var effective = DateTime.SpecifyKind(dateInput, kind);
+            var dto = new DateTimeOffset(effective);
+
+            unixSeconds = dto.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            unixMilliseconds = dto.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+            dateUtcSummary = dto.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+            dateLocalSummary = dto.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss 'GMT'zzz", CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex)
+        {
+            dateError = ex.Message;
+            unixSeconds = null;
+            unixMilliseconds = null;
+            dateUtcSummary = null;
+            dateLocalSummary = null;
+        }
+    }
+
+    private void UseCurrentTimestamp()
+    {
+        var now = DateTimeOffset.UtcNow;
+        timestampInput = timestampUnit == TimestampUnit.Seconds
+            ? now.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture)
+            : now.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        ConvertTimestamp();
+    }
+
+    private void UseNowForDate()
+    {
+        dateInput = DateTime.Now;
+        dateInterpretation = TimeZoneSelection.Local;
+        ConvertDate();
+    }
+
+    private void FillTimestampFromDate()
+    {
+        if (string.IsNullOrWhiteSpace(unixSeconds))
+        {
+            return;
+        }
+
+        timestampUnit = TimestampUnit.Seconds;
+        timestampInput = unixSeconds;
+        timestampOutputZone = TimeZoneSelection.Both;
+        ConvertTimestamp();
+    }
+
+    private string BuildRelativeDescription(DateTimeOffset utc)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var diff = now - utc;
+        var direction = diff.TotalSeconds >= 0 ? "ago" : "from now";
+        var span = diff.Duration();
+
+        string unit;
+        double value;
+        if (span.TotalDays >= 365)
+        {
+            value = span.TotalDays / 365;
+            unit = "year";
+        }
+        else if (span.TotalDays >= 30)
+        {
+            value = span.TotalDays / 30;
+            unit = "month";
+        }
+        else if (span.TotalDays >= 1)
+        {
+            value = span.TotalDays;
+            unit = "day";
+        }
+        else if (span.TotalHours >= 1)
+        {
+            value = span.TotalHours;
+            unit = "hour";
+        }
+        else if (span.TotalMinutes >= 1)
+        {
+            value = span.TotalMinutes;
+            unit = "minute";
+        }
+        else
+        {
+            value = span.TotalSeconds;
+            unit = "second";
+        }
+
+        var rounded = Math.Max(1, (int)Math.Round(value));
+        var suffix = rounded == 1 ? unit : unit + "s";
+        return $"Approximately {rounded} {suffix} {direction}.";
+    }
+
+    private async Task CopyAsync(string? value, string buttonId)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            await JSRuntime.InvokeVoidAsync("copyToClipboard", value, buttonId);
+        }
+    }
+}

--- a/DevTools/Shared/MainLayout.razor
+++ b/DevTools/Shared/MainLayout.razor
@@ -13,6 +13,9 @@
                     <NavLink href="stringformatter" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">String Format</NavLink>
                     <NavLink href="jsoneditsort" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">JSON Edit</NavLink>
                     <NavLink href="compare" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">Compare</NavLink>
+                    <NavLink href="unixtimestamp" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">Timestamp</NavLink>
+                    <NavLink href="jwtdecoder" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">JWT</NavLink>
+                    <NavLink href="regextester" ActiveClass="bg-blue-700" class="px-3 py-1 text-white hover:bg-blue-700 rounded transition-colors text-sm">Regex</NavLink>
                 </nav>
                 
                 <!-- Mobile Menu Button -->
@@ -33,6 +36,9 @@
                     <NavLink href="stringformatter" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">String Formatter</NavLink>
                     <NavLink href="jsoneditsort" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">JSON Edit/Sort</NavLink>
                     <NavLink href="compare" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">Compare</NavLink>
+                    <NavLink href="unixtimestamp" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">Timestamp Converter</NavLink>
+                    <NavLink href="jwtdecoder" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">JWT Decoder</NavLink>
+                    <NavLink href="regextester" ActiveClass="bg-blue-700" class="px-3 py-2 text-white hover:bg-blue-700 rounded transition-colors">Regex Tester</NavLink>
                 </div>
             </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # developer-tools
 
-PWA Web App with commenly used developer tools.
+Progressive Web App that bundles a curated set of everyday developer utilities. The home page now features a search
+bar and richer descriptions so you can quickly find the tool you need.
 
-* Replace line breaks
-* Guid Helpers
-* String Formatter
-* URL Encode/Decode
-* Base64 Encode/Decode
+## Included tools
+
+- **Replace Line Breaks** – Turn newline separated content into SQL statements, comma separated lists, and more.
+- **GUID Helpers** – Generate GUIDs or convert them to and from numeric representations.
+- **String Formatter** – Format JSON and SQL, convert casing, and perform URL/Base64 encoding or decoding.
+- **JSON Edit/Sort** – Sort JSON structures and drop unwanted properties before sharing data.
+- **Compare Tool** – Review differences between two snippets of text or code with a diff viewer.
+- **Unix Timestamp Converter** – Convert timestamps to readable dates (local and UTC) and vice versa.
+- **JWT Decoder** – Inspect JSON Web Tokens completely offline with formatted JSON and claim summaries.
+- **Regex Tester** – Experiment with regular expressions, highlight matches, and preview replacements in real time.
+
+## Development
+
+```
+dotnet build
+```
+
+Run the app with `dotnet run` inside the `DevTools` project for local testing.


### PR DESCRIPTION
## Summary
- refresh the home page with a tool search experience, richer descriptions, and badges for new utilities
- expand the navigation to surface newly added tools alongside the existing set
- add Unix timestamp conversion, JWT decoding, and regex testing pages with inline guidance and copy helpers
- update the README to document the broadened toolset and basic development commands

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e030e7c4bc8327afcfa4617bd87590